### PR TITLE
NW: Fix for referencing YTPlayerView-iframe-player

### DIFF
--- a/Classes/YTPlayerView.m
+++ b/Classes/YTPlayerView.m
@@ -683,9 +683,7 @@ NSString static *const kYTPlayerStaticProxyRegexPattern = @"^https://content.goo
   [self addSubview:self.webView];
 
   NSError *error = nil;
-  NSString *path = [[NSBundle mainBundle] pathForResource:@"YTPlayerView-iframe-player"
-                                                   ofType:@"html"
-                                              inDirectory:@"Assets"];
+  NSString *path = [[NSBundle mainBundle] pathForResource:@"YTPlayerView-iframe-player" ofType:@"html"];
     
   // in case of using Swift and embedded frameworks, resources included not in main bundle,
   // but in framework bundle


### PR DESCRIPTION
This fixes the path for referencing Assets/ folder. We no longer require the asset to be at the root of the project source in order to reference the html file.
